### PR TITLE
Added Semigroup instance

### DIFF
--- a/src/Control/Monad/Plus.hs
+++ b/src/Control/Monad/Plus.hs
@@ -1,5 +1,5 @@
 
-{-# LANGUAGE DeriveFunctor, DeriveFoldable, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE CPP, DeriveFunctor, DeriveFoldable, GeneralizedNewtypeDeriving #-}
 
 -------------------------------------------------------------------------------------
 -- |
@@ -261,8 +261,13 @@ instance Category Partial where
         y <- g x
         f y
 
+#if MIN_VERSION_base(4,11,0)
+instance Semigroup (Partial a b) where
+  (<>) = mplus
+#endif
+
 instance Monoid (Partial a b) where
     mempty  = mzero
+#if !MIN_VERSION_base(4,11,0)
     mappend = mplus
-
-
+#endif


### PR DESCRIPTION
GHC 8.4.1-alpha1 was [announced](https://mail.haskell.org/pipermail/ghc-devs/2017-December/015235.html). While testing [Agda](https://github.com/agda/agda) with this version of GHC, I got the following error:

```
$ cabal install
...
[2 of 2] Compiling Control.Monad.Plus (src/Control/Monad/Plus.hs, dist/build/Control/Monad/Plus.o)

src/Control/Monad/Plus.hs:256:10: error:
    • No instance for (Semigroup (Partial a b))
        arising from the superclasses of an instance declaration
    • In the instance declaration for ‘Monoid (Partial a b)’
    |
256 | instance Monoid (Partial a b) where
    |          ^^^^^^^^^^^^^^^^^^^^
Failed to install monadplus-1.4.2
```

This PR fix the above issue.

Blocking https://github.com/agda/agda/issues/2878.