### PR TITLE
Fix syntax of 'cabal-version' to satisfy 'cabal check'

### DIFF
--- a/monadplus.cabal
+++ b/monadplus.cabal
@@ -1,4 +1,4 @@
-cabal-version:      >= 1.18
+cabal-version:      1.18
 name:               monadplus
 version:            1.4.3
 author:             Hans Hoglund


### PR DESCRIPTION
From 1.12, the syntax required by `cabal check` is `cabal-version: x.y` rather than `>= x.y`.

P.S. to 
- #10
